### PR TITLE
fix: change a giscus-component to my giscus component

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "contentlayer": "^0.3.4",
     "date-fns": "^3.3.1",
     "framer-motion": "^11.0.0",
+    "giscus": "^1.4.0",
     "github-slugger": "^2.0.0",
     "lucide-react": "^0.320.0",
     "next": "14.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ dependencies:
   framer-motion:
     specifier: ^11.0.0
     version: 11.0.0(react-dom@18.2.0)(react@18.2.0)
+  giscus:
+    specifier: ^1.4.0
+    version: 1.4.0
   github-slugger:
     specifier: ^2.0.0
     version: 2.0.0

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import Giscus from '@giscus/react';
+// import Giscus from '@giscus/react';
 import { usePathname } from 'next/navigation';
 import { useTheme } from 'next-themes';
 
 import appConfig from '@/app.config';
+
+import { MyGiscus } from './MyGiscus';
 
 export function Comment() {
   const pathname = usePathname();
@@ -16,7 +18,7 @@ export function Comment() {
 
   return (
     <div className="mt-10">
-      <Giscus
+      <MyGiscus
         key={`${pathname}_${theme}`}
         id="comments"
         repo="JHSeo-git/seonest-comments"

--- a/src/components/MyGiscus.tsx
+++ b/src/components/MyGiscus.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import type { GiscusProps } from '@giscus/react';
+import * as React from 'react';
+
+// TODO:
+// remove this component when the issue is resolved.
+// - https://github.com/giscus/giscus-component/issues/1976
+export function MyGiscus({
+  id,
+  host,
+  repo,
+  repoId,
+  category,
+  categoryId,
+  mapping,
+  term,
+  strict,
+  reactionsEnabled,
+  emitMetadata,
+  inputPosition,
+  theme,
+  lang,
+  loading,
+}: GiscusProps) {
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    if (mounted) return;
+    import('giscus');
+    setMounted(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (!mounted) return null;
+
+  return (
+    <giscus-widget
+      id={id}
+      host={host}
+      repo={repo}
+      repoid={repoId}
+      category={category}
+      categoryid={categoryId}
+      mapping={mapping}
+      term={term}
+      strict={strict}
+      reactionsenabled={reactionsEnabled}
+      emitmetadata={emitMetadata}
+      inputposition={inputPosition}
+      theme={theme}
+      lang={lang}
+      loading={loading}
+    />
+  );
+}

--- a/src/types/giscus.d.ts
+++ b/src/types/giscus.d.ts
@@ -1,0 +1,26 @@
+// TODO:
+// remove this component when the issue is resolved.
+// - https://github.com/giscus/giscus-component/issues/1976
+interface GiscusWidgetAttributes {
+  id?: string;
+  host?: string;
+  repo: `${string}/${string}`;
+  repoid: string;
+  category?: string;
+  categoryid?: string;
+  mapping: import('@giscus/react').Mapping;
+  term?: string;
+  theme?: import('@giscus/react').Theme;
+  strict?: import('@giscus/react').BooleanString;
+  reactionsenabled?: import('@giscus/react').BooleanString;
+  emitmetadata?: import('@giscus/react').BooleanString;
+  inputposition?: import('@giscus/react').InputPosition;
+  lang?: import('@giscus/react').AvailableLanguage;
+  loading?: import('@giscus/react').Loading;
+}
+
+declare namespace JSX {
+  interface IntrinsicElements {
+    'giscus-widget': GiscusWidgetAttributes;
+  }
+}


### PR DESCRIPTION
## 이슈
Next.js 14.1 업데이트 이후 gitcus/react 컴포넌트 사용시 "exports is not defined" 에러 발생

## 원인
gitcus/react 번들링이 cjs 만 제공하는데 Next.js 14.1 버전에서 module resolve시 이슈

## 해결
gitcus component 코드 my-component로 복사 후 patch 와 비슷하게 진행



