### PR TITLE
docs(principles): add abstraction-as-actor and redundant-modifier rules

### DIFF
--- a/.agents/references/writing-principles.md
+++ b/.agents/references/writing-principles.md
@@ -251,6 +251,18 @@ For three or more items, use a list — but only if the items are actually
 parallel. Mixed types in a list ("the cache is fast, the disk is slow, and
 we use Redis") signal that prose would have served better.
 
+### Cut modifiers the context already carries
+
+An adjective or adverb that only repeats what nearby sentences have already
+established is decoration, not information. It reads as padding — and when the
+modifier is carried over from a source language that front-loads description,
+it reads translated. Once the surrounding text sets a quality, let the noun
+stand on its own.
+
+The test: delete the modifier and reread. If a careful reader loses nothing
+they didn't already know, leave it deleted. This is distinct from stock
+intensifiers — the word may be a perfectly good adjective, just redundant here.
+
 ## Anti-Patterns
 
 Reject on sight. If the draft contains any of these, rewrite the surrounding
@@ -356,6 +368,14 @@ usually fail. The categories overlap; one sentence can hit several at once.
 - **Redundant demonstratives.** English requires demonstratives on
   references that Korean elides. When a Korean sentence carries a
   demonstrative on every reference, drop the ones context already supplies.
+- **Abstraction as actor.** English readily puts an abstract noun in the
+  subject slot of a vivid or evaluative predicate — a concept is "right", an
+  assumption "quietly collapses", reality "arrives". Rendered straight, a
+  Korean sentence that makes an abstraction act or get judged like an agent
+  reads translated and stiff. Prefer a concrete subject — the person, the
+  tool, the code, the team — or recast so a verb carries the idea. This bites
+  hardest in headings and topic sentences, where an abstract concept in the
+  subject slot sounds like a dictionary entry instead of a claim.
 
 Read each sentence aloud. If a Korean speaker would naturally rephrase it,
 the calque is the problem — patches usually fail, so rewrite the thought.


### PR DESCRIPTION
## 요약

writing/review 두 스킬이 공유하는 `writing-principles.md`에 일반 원칙 2개를 추가합니다. 특정 문구 블랙리스트가 아니라 같은 부류를 포괄하는 일반 규칙입니다.

## 추가한 규칙

- **Readability › Cut modifiers the context already carries** — 주변 문맥이 이미 담은 수식어는 정보가 아니라 장식. "지우고 다시 읽어 손실 없으면 지운 채로 둔다" 테스트. (stock intensifier 규칙과 구분)
- **Calque traps › Abstraction as actor** — 추상명사를 생생한/평가적 술어의 주어로 세우는 직역투(개념이 "맞다", 가정이 "무너진다", 현실이 "도착한다"). 구체적 주어로 바꾸거나 동사가 뜻을 지게 재구성. 소제목·화제문에서 특히.

## 배경

블로그 글 다듬기(별도 PR) 과정에서 자동 리뷰 패스가 놓친 번역투·어색한 표현이 반복 발견되어, 재사용 가능한 일반 원칙으로 성문화했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
